### PR TITLE
delete strip()

### DIFF
--- a/resolvconfReader.py
+++ b/resolvconfReader.py
@@ -5,7 +5,7 @@ def get_resolvers():
 		with open( '/etc/resolv.conf', 'r' ) as resolvconf:
 			for line in resolvconf.readlines():
 				if 'nameserver' in line:
-					resolvers.append( line.split( ' ' )[ 1 ].strip() )
+					resolvers.append( line.split()[ 1 ] )
 		return resolvers
 	except IOError as error:
 		return error.strerror


### PR DESCRIPTION
It's not necessary to use  strip() for deleting whitespace characters, because split() without  any arguments  do it. 
" string.split(s[, sep[, maxsplit]])
    Return a list of the words of the string s. If the optional second argument sep is absent or None, the words are separated by arbitrary strings of whitespace characters (space, tab, newline, return, formfeed)."  from https://docs.python.org/2/library/string.html
